### PR TITLE
feat(categories): polish category pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,50 @@
 - Phase 6 (Cart & Checkout) — PARTIAL: Cart slice and UI (`src/store/cart.slice.ts`, `src/components/cart/*`) and checkout confirmation page (`/checkout/confirmation`) exist; remaining work: server actions, Order/Payment domain, checkout flows, cart persistence and tests.
 - Phase 7 (Hardening) — TODO: add error handling, SEO improvements, logging, and tests (unit/integration/e2e); currently only Cosmic error logging in `src/infra/cosmic/error.ts`.
 
+## Remaining Work Breakdown (clear tasks)
+### Phase 2 — Category pages UI polish
+1. Refine category list cards in `src/app/(storefront)/categories`:
+   - Improve hierarchy (title, image, meta).
+   - Add consistent spacing/typography and hover states.
+2. Refine category detail cards in `src/app/(storefront)/categories/[slug]`:
+   - Standardize product/subcategory card layout.
+   - Add empty/edge-state messaging (no subcategories/products).
+3. Ensure responsive layout parity across breakpoints:
+   - Verify grid/stack behavior for list and detail pages.
+   - Confirm consistent spacing with Tailwind tokens.
+
+### Phase 6 — Cart & Checkout completion
+1. Domain modeling:
+   - Add Order/Payment schemas in `src/models` with Zod validation.
+   - Add types and mappers to map API/checkout payloads.
+2. Server actions / API integration:
+   - Create server actions under `src/app/(server)` for cart + checkout.
+   - Validate payloads and return standardized responses.
+3. Checkout flow:
+   - Implement step-based UI (shipping, payment, review).
+   - Connect cart to checkout summary + totals.
+4. Cart persistence:
+   - Persist cart state to storage (localStorage or cookies).
+   - Add hydration logic and reconciliation on load.
+5. UX hardening:
+   - Add loading states, error messages, and disabled actions.
+   - Ensure cart updates are optimistic but resilient.
+
+### Phase 7 — Hardening
+1. Error handling:
+   - Centralize error boundaries for storefront routes.
+   - Add user-friendly fallbacks on fetch failures.
+2. SEO improvements:
+   - Add metadata (title, description, OG) per key page.
+   - Ensure canonical URLs and structured data where relevant.
+3. Logging:
+   - Add structured logging for checkout and cart events.
+   - Capture errors with context (route, payload size, status).
+4. Tests:
+   - Add unit tests for domain models and mappers.
+   - Add integration tests for search and checkout flows.
+   - Add e2e smoke tests for critical storefront flows.
+
 ## Project Structure & Module Organization
 - Source lives in `src/` using Next.js App Router + TypeScript.
 - Key folders:

--- a/src/app/(storefront)/categories/[slug]/page.tsx
+++ b/src/app/(storefront)/categories/[slug]/page.tsx
@@ -1,6 +1,18 @@
-import { buttonVariants, Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "@/components";
+import {
+  AspectRatio,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components";
 import { categoryRepository } from "@/infra/cosmic/category/category.repo";
-import { ArrowLeft, BoxSelectIcon } from "lucide-react";
+import { ArrowLeft, BoxSelectIcon, TagIcon } from "lucide-react";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
@@ -13,118 +25,179 @@ export default async function CategoryDetailPage(props: PageProps<'/categories/[
   }
 
   return (
-    <main className="px-6 py-8">
-      <section>
-        <h1 className="text-2xl font-semibold mb-4 flex items-center gap-2">
-          <Link href="/categories" className={buttonVariants({ variant: 'ghost' })}>
-            <ArrowLeft />
-          </Link>
-          <span>{category.title}</span>
-        </h1>
+    <main className="mx-auto w-full max-w-6xl px-6 py-10 space-y-10">
+      <section className="grid gap-6 md:grid-cols-[minmax(0,1fr)_240px] md:items-start">
+        <div className="space-y-4">
+          <div className="flex items-center gap-3">
+            <Link
+              href="/categories"
+              className="flex h-9 w-9 items-center justify-center rounded-full border text-muted-foreground transition hover:text-foreground"
+              aria-label="Back to categories"
+            >
+              <ArrowLeft className="h-4 w-4" />
+            </Link>
+            <div>
+              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Category</p>
+              <h1 className="text-3xl font-semibold">{category.title}</h1>
+            </div>
+          </div>
 
-        <div className="aspect-square w-40 rounded-md border mb-4">
-          {category.thumbnailUrl && (
-            <img
-              src={category.thumbnailUrl}
-              alt={category.title}
-              className="w-full h-full rounded-md object-cover"
-            />
+          {category.description && (
+            <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground">
+              {category.description}
+            </p>
           )}
         </div>
 
-
-        {category.description && (
-          <p className="max-w-2xl text-gray-700 leading-relaxed">
-            {category.description}
-          </p>
-        )}
-      </section>
-      <section className="mt-6 flex flex-col gap-4">
-        {category.parentId && (
-          <Link href={`/categories/${category.parentSlug}`}>
-            <div className="aspect-square w-20 rounded-md border mb-2">
-              {category.parentThumbnail && (
+        <Card className="overflow-hidden">
+          <CardContent className="p-0">
+            <AspectRatio ratio={1}>
+              {category.thumbnailUrl ? (
                 <img
-                  src={category.parentThumbnail}
-                  alt={category.parentTitle}
-                  className="w-full h-full rounded-md object-cover"
+                  src={category.thumbnailUrl}
+                  alt={category.title}
+                  className="h-full w-full object-cover"
                 />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center bg-muted/40 text-muted-foreground">
+                  <TagIcon className="h-8 w-8" />
+                </div>
               )}
-            </div>
-            <h2 className="text-xl font-semibold mb-4 flex items-center gap-2">
-              <span>{category.parentTitle ?? ''}</span>
-            </h2>
-          </Link>
-        )}
-
-        {category.subCategories.map((subCategory) => (
-          <Link key={subCategory.id} href={`/categories/${subCategory.slug}`}>
-            <div className="aspect-square w-20 rounded-md border mb-2">
-              {subCategory.thumbnailUrl && (
-                <img
-                  src={subCategory.thumbnailUrl}
-                  alt={subCategory.title}
-                  className="w-full h-full rounded-md object-cover"
-                />
-              )}
-            </div>
-            <h2 className="text-xl font-semibold mb-4 flex items-center gap-2">
-              <span>{subCategory.title ?? ''}</span>
-            </h2>
-            {subCategory.description && (
-              <p className="text-gray-700 leading-relaxed line-clamp-2">
-                {subCategory.description}
-              </p>
-            )}
-          </Link>
-        ))}
-
+            </AspectRatio>
+          </CardContent>
+        </Card>
       </section>
 
-      <section className="mt-6 flex flex-col gap-4">
-        <h3 className="text-xl font-semibold mb-2 flex items-center gap-2">
-          <span>Products</span>
-        </h3>
+      <section className="space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h2 className="text-xl font-semibold">Subcategories</h2>
+          {category.parentId && category.parentSlug && (
+            <Link href={`/categories/${category.parentSlug}`} className="text-sm text-muted-foreground hover:text-foreground">
+              View parent category
+            </Link>
+          )}
+        </div>
 
-        {category.products.map((product) => (
-          <Link key={product.id} href={`/products/${product.slug}`}>
-            <div className="aspect-square w-20 rounded-md border mb-1">
-              {product.thumbnailUrl && (
-                <img
-                  src={product.thumbnailUrl}
-                  alt={product.title}
-                  className="w-full h-full rounded-md object-cover"
-                />
-              )}
-            </div>
-            <h3 className="text-md font-semibold mb-1 flex items-center gap-2">
-              <span>{product.title ?? ''}</span>
-            </h3>
-            <p className="leading-relaxed">
-                {product.price?.toLocaleString('vi-VN', { style: 'currency', currency: 'VND' })}
-              </p>
-            {product.shortDescription && (
-              <p className="text-gray-700 text-sm leading-relaxed line-clamp-2">
-                {product.shortDescription}
-              </p>
-            )}
+        {category.parentId && category.parentSlug && (
+          <Link href={`/categories/${category.parentSlug}`} className="block">
+            <Card className="border-dashed">
+              <CardHeader>
+                <CardTitle className="text-base">Parent category</CardTitle>
+                <CardDescription>{category.parentTitle ?? "Back to parent"}</CardDescription>
+              </CardHeader>
+            </Card>
           </Link>
-        ))}
+        )}
 
-        {category.products.length === 0 && (
+        {category.subCategories.length > 0 ? (
+          <ul className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {category.subCategories.map((subCategory) => (
+              <li key={subCategory.id}>
+                <Link href={`/categories/${subCategory.slug}`} className="group block h-full">
+                  <Card className="h-full transition duration-200 group-hover:-translate-y-1 group-hover:shadow-md">
+                    <CardContent className="flex h-full flex-col gap-4">
+                      <div className="overflow-hidden rounded-lg border bg-muted/30">
+                        <AspectRatio ratio={4 / 3} className="bg-muted/40">
+                          {subCategory.thumbnailUrl ? (
+                            <img
+                              src={subCategory.thumbnailUrl}
+                              alt={subCategory.title}
+                              className="h-full w-full object-cover transition duration-300 group-hover:scale-105"
+                            />
+                          ) : (
+                            <div className="flex h-full w-full items-center justify-center text-muted-foreground">
+                              <TagIcon className="h-7 w-7" />
+                            </div>
+                          )}
+                        </AspectRatio>
+                      </div>
+                      <div className="flex flex-1 flex-col gap-2">
+                        <h3 className="text-lg font-semibold">{subCategory.title ?? ""}</h3>
+                        {subCategory.description && (
+                          <p className="text-sm text-muted-foreground line-clamp-2">
+                            {subCategory.description}
+                          </p>
+                        )}
+                      </div>
+                      <span className="text-sm text-muted-foreground">Explore</span>
+                    </CardContent>
+                  </Card>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <Empty>
+            <EmptyHeader>
+              <EmptyMedia>
+                <TagIcon />
+              </EmptyMedia>
+              <EmptyTitle>No subcategories yet</EmptyTitle>
+              <EmptyDescription>This category does not have subcategories.</EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        )}
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold">Products</h2>
+          <p className="text-sm text-muted-foreground">{category.products.length} items</p>
+        </div>
+
+        {category.products.length > 0 ? (
+          <ul className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {category.products.map((product) => (
+              <li key={product.id}>
+                <Link href={`/products/${product.slug}`} className="group block h-full">
+                  <Card className="h-full transition duration-200 group-hover:-translate-y-1 group-hover:shadow-md">
+                    <CardContent className="flex h-full flex-col gap-4">
+                      <div className="overflow-hidden rounded-lg border bg-muted/30">
+                        <AspectRatio ratio={4 / 3} className="bg-muted/40">
+                          {product.thumbnailUrl ? (
+                            <img
+                              src={product.thumbnailUrl}
+                              alt={product.title}
+                              className="h-full w-full object-cover transition duration-300 group-hover:scale-105"
+                            />
+                          ) : (
+                            <div className="flex h-full w-full items-center justify-center text-muted-foreground">
+                              <BoxSelectIcon className="h-7 w-7" />
+                            </div>
+                          )}
+                        </AspectRatio>
+                      </div>
+                      <div className="flex flex-1 flex-col gap-2">
+                        <h3 className="text-lg font-semibold">{product.title ?? ""}</h3>
+                        {product.shortDescription && (
+                          <p className="text-sm text-muted-foreground line-clamp-2">
+                            {product.shortDescription}
+                          </p>
+                        )}
+                      </div>
+                      <p className="text-sm font-semibold text-foreground">
+                        {product.price?.toLocaleString("vi-VN", {
+                          style: "currency",
+                          currency: "VND",
+                        })}
+                      </p>
+                    </CardContent>
+                  </Card>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        ) : (
           <Empty>
             <EmptyHeader>
               <EmptyMedia>
                 <BoxSelectIcon />
               </EmptyMedia>
               <EmptyTitle>No products found</EmptyTitle>
-              <EmptyDescription>
-                No products were found in this category.
-              </EmptyDescription>
+              <EmptyDescription>No products were found in this category.</EmptyDescription>
             </EmptyHeader>
           </Empty>
         )}
-
       </section>
     </main>
   );

--- a/src/app/(storefront)/categories/page.tsx
+++ b/src/app/(storefront)/categories/page.tsx
@@ -1,7 +1,17 @@
-import { Button, buttonVariants, Empty, EmptyContent, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "@/components";
+import {
+  AspectRatio,
+  Button,
+  Card,
+  CardContent,
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components";
 import { categoryRepository } from "@/infra/cosmic/category/category.repo";
-import { cn } from "@/lib/utils";
-import { RefreshCcwIcon, TagIcon } from "lucide-react";
+import { ArrowRight, RefreshCcwIcon, TagIcon } from "lucide-react";
 import Link from "next/link";
 
 export default async function CategoryPage() {
@@ -28,31 +38,54 @@ export default async function CategoryPage() {
   );
 
   return (
-    <main className="px-6 py-8">
-      <h1 className="text-2xl font-semibold mb-6">Categories ({total})</h1>
+    <main className="mx-auto w-full max-w-6xl px-6 py-10">
+      <header className="mb-8 flex flex-col gap-2">
+        <p className="text-sm font-medium uppercase tracking-wide text-muted-foreground">Browse</p>
+        <h1 className="text-3xl font-semibold">Categories</h1>
+        <p className="text-sm text-muted-foreground">Discover collections curated for your storefront. ({total} total)</p>
+      </header>
 
-
-      <ul className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <ul className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
         {categories.map((category) => (
-          <li key={category.id} className="border rounded-lg p-4">
-            <div className="mb-2 aspect-4/3 w-full rounded-md border">
-              {category.thumbnailUrl && (
-                <img
-                  src={category.thumbnailUrl}
-                  alt={category.title}
-                  className="rounded-md object-cover"
-                />
-              )}
-            </div>
-            <div className="font-medium">{category.title}</div>
-            {category.description && (
-              <p className="text-sm text-gray-500 line-clamp-2">
-                {category.description}
-              </p>
-            )}
-            <div className="mt-4 flex justify-end">
-              <Link className={cn(buttonVariants({}))} href={{ pathname: `/categories/${category.slug}` }}>See detail</Link>
-            </div>
+          <li key={category.id} className="h-full">
+            <Link
+              className="group block h-full"
+              href={{ pathname: `/categories/${category.slug}` }}
+            >
+              <Card className="h-full transition duration-200 group-hover:-translate-y-1 group-hover:shadow-md">
+                <CardContent className="flex h-full flex-col gap-4">
+                  <div className="overflow-hidden rounded-lg border bg-muted/30">
+                    <AspectRatio ratio={4 / 3} className="bg-muted/40">
+                      {category.thumbnailUrl ? (
+                        <img
+                          src={category.thumbnailUrl}
+                          alt={category.title}
+                          className="h-full w-full object-cover transition duration-300 group-hover:scale-105"
+                        />
+                      ) : (
+                        <div className="flex h-full w-full items-center justify-center text-muted-foreground">
+                          <TagIcon className="h-8 w-8" />
+                        </div>
+                      )}
+                    </AspectRatio>
+                  </div>
+
+                  <div className="flex flex-1 flex-col gap-2">
+                    <div className="text-lg font-semibold text-foreground">{category.title}</div>
+                    {category.description && (
+                      <p className="text-sm text-muted-foreground line-clamp-2">
+                        {category.description}
+                      </p>
+                    )}
+                  </div>
+
+                  <div className="mt-auto flex items-center justify-between text-sm text-muted-foreground">
+                    <span>View category</span>
+                    <ArrowRight className="h-4 w-4 transition group-hover:translate-x-1" />
+                  </div>
+                </CardContent>
+              </Card>
+            </Link>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
### Motivation
- Polish the Category pages UI as part of Phase 2 to improve visual hierarchy and usability.
- Replace the basic list layout with consistent card-based components and placeholders for missing images.
- Provide clearer empty/edge states and responsive grids for subcategories and products.

### Description
- Restyled the categories list in `src/app/(storefront)/categories/page.tsx` to a card-based grid using `Card` and `AspectRatio` with hover interactions and a richer header.
- Revamped the category detail page in `src/app/(storefront)/categories/[slug]/page.tsx` to a structured layout with thumbnail card, parent/subcategory cards, product grids, and improved empty states.
- Updated component imports (added `Card`, `CardContent`, `CardHeader`, `CardTitle`, `CardDescription`, `AspectRatio`, icons) and removed the unused `cn` import.

### Testing
- No unit or integration tests were executed for this change.
- Attempted automated E2E via `Playwright` to capture screenshots, but the browser crashed in this environment and the script failed.
- Performed `yarn install` and started the dev server with `yarn dev` as a smoke run; the server started but the Playwright capture failed due to a headless browser crash.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694263c1d0388329b072149c040b59b4)